### PR TITLE
Add logging support

### DIFF
--- a/backend/gradio_pianoroll/__init__.py
+++ b/backend/gradio_pianoroll/__init__.py
@@ -1,4 +1,20 @@
+from __future__ import annotations
+
+import logging
+import os
+
 from .pianoroll import PianoRoll
+
+logger = logging.getLogger(__name__)
+
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("[%(levelname)s] %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+level_str = os.environ.get("GRADIO_PIANOROLL_LOG_LEVEL", "WARNING").upper()
+logger.setLevel(getattr(logging, level_str, logging.WARNING))
 
 # Core component is always available
 __all__ = ["PianoRoll"]

--- a/backend/gradio_pianoroll/data_models.py
+++ b/backend/gradio_pianoroll/data_models.py
@@ -5,8 +5,12 @@ Piano Roll 데이터 모델과 유효성 검사 함수들
 """
 
 from __future__ import annotations
-from typing import TypedDict, Optional, List, Dict, Any, Union
+
+import logging
 import warnings
+from typing import Any, Dict, List, Optional, TypedDict, Union
+
+logger = logging.getLogger(__name__)
 
 
 class TimeSignature(TypedDict):
@@ -254,8 +258,9 @@ def ensure_note_ids(data: Dict[str, Any]) -> Dict[str, Any]:
             modified = True
 
     if modified:
-        print(
-            f"🔧 Auto-generated IDs for {sum(1 for note in data['notes'] if not note.get('id'))} notes"
+        logger.debug(
+            "🔧 Auto-generated IDs for %d notes",
+            sum(1 for note in data["notes"] if not note.get("id")),
         )
 
     return data

--- a/backend/gradio_pianoroll/pianoroll.py
+++ b/backend/gradio_pianoroll/pianoroll.py
@@ -1,28 +1,30 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Dict, Union
+
+logger = logging.getLogger(__name__)
 
 from gradio.components.base import Component
 from gradio.events import Events
 from gradio.i18n import I18nData
 
-from .timing_utils import (
-    generate_note_id,
-    pixels_to_flicks,
-    pixels_to_seconds,
-    pixels_to_beats,
-    pixels_to_ticks,
-    pixels_to_samples,
-    calculate_all_timing_data,
-    create_note_with_timing,
-)
-
 from .data_models import (
     PianoRollData,
-    validate_and_warn,
     clean_piano_roll_data,
     ensure_note_ids,
+    validate_and_warn,
+)
+from .timing_utils import (
+    calculate_all_timing_data,
+    create_note_with_timing,
+    generate_note_id,
+    pixels_to_beats,
+    pixels_to_flicks,
+    pixels_to_samples,
+    pixels_to_seconds,
+    pixels_to_ticks,
 )
 
 if TYPE_CHECKING:
@@ -321,11 +323,15 @@ class PianoRoll(Component):
                     value["use_backend_audio"] = False
 
             # Add debug logging
-            print(f"🔊 [postprocess] Backend audio data processed:")
-            print(f"   - audio_data present: {bool(value.get('audio_data'))}")
-            print(f"   - use_backend_audio: {value.get('use_backend_audio', False)}")
-            print(f"   - curve_data present: {bool(value.get('curve_data'))}")
-            print(f"   - segment_data present: {bool(value.get('segment_data'))}")
+            logger.debug("🔊 [postprocess] Backend audio data processed:")
+            logger.debug("   - audio_data present: %s", bool(value.get("audio_data")))
+            logger.debug(
+                "   - use_backend_audio: %s", value.get("use_backend_audio", False)
+            )
+            logger.debug("   - curve_data present: %s", bool(value.get("curve_data")))
+            logger.debug(
+                "   - segment_data present: %s", bool(value.get("segment_data"))
+            )
 
         return value
 


### PR DESCRIPTION
## Summary
- use Python logging in data model helpers
- configure the package logger with environment based levels
- switch pianoroll debug `print` statements to `logger.debug`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517ce915848328980f5381e94dae7c