### PR TITLE
Add dataclass exports and TypeScript types

### DIFF
--- a/backend/gradio_pianoroll/__init__.py
+++ b/backend/gradio_pianoroll/__init__.py
@@ -1,7 +1,21 @@
 from .pianoroll import PianoRoll
+from .data_models import (
+    TimeSignatureData,
+    NoteData,
+    LineDataPointData,
+    LineLayerConfigData,
+    PianoRollDataClass,
+)
 
 # Core component is always available
-__all__ = ["PianoRoll"]
+__all__ = [
+    "PianoRoll",
+    "TimeSignatureData",
+    "NoteData",
+    "LineDataPointData",
+    "LineLayerConfigData",
+    "PianoRollDataClass",
+]
 
 # Optional utilities - users can import explicitly if needed
 # Example usage:

--- a/backend/gradio_pianoroll/pianoroll.py
+++ b/backend/gradio_pianoroll/pianoroll.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Dict, Union
 

--- a/backend/gradio_pianoroll/pianoroll.py
+++ b/backend/gradio_pianoroll/pianoroll.py
@@ -171,6 +171,8 @@ class PianoRoll(Component):
 
             # ID 보장 및 타이밍 데이터 생성
             self.value = ensure_note_ids(validated_value)
+            if dataclasses.is_dataclass(self.value):
+                self.value = dataclasses.asdict(self.value)
 
             # Ensure all notes have timing values, generate them if missing
             if "notes" in self.value and self.value["notes"]:
@@ -240,6 +242,8 @@ class PianoRoll(Component):
             cleaned_payload, "Frontend piano roll data"
         )
 
+        if dataclasses.is_dataclass(validated_payload):
+            return dataclasses.asdict(validated_payload)
         return validated_payload
 
     def postprocess(self, value):
@@ -251,6 +255,9 @@ class PianoRoll(Component):
         Returns:
             The postprocessed data (with all required fields).
         """
+        if dataclasses.is_dataclass(value):
+            value = dataclasses.asdict(value)
+
         # Ensure all notes have IDs and all timing values when sending to frontend
         if value and "notes" in value and value["notes"]:
             pixels_per_beat = value.get("pixelsPerBeat", 80)

--- a/backend/gradio_pianoroll/utils/research.py
+++ b/backend/gradio_pianoroll/utils/research.py
@@ -13,7 +13,11 @@ if TYPE_CHECKING:
     import gradio as gr
 
 from ..timing_utils import generate_note_id
-from ..data_models import PianoRollData, Note, clean_piano_roll_data
+from ..data_models import (
+    PianoRollDataClass,
+    NoteData,
+    clean_piano_roll_data,
+)
 
 # =============================================================================
 # 1. 빠른 생성 함수들 (Quick Creation)
@@ -24,7 +28,7 @@ def from_notes(
     notes: List[Tuple[int, float, float]],
     tempo: int = 120,
     lyrics: Optional[List[str]] = None,
-) -> PianoRollData:
+) -> PianoRollDataClass:
     """
     간단한 노트 리스트에서 피아노롤 데이터 생성
 
@@ -62,7 +66,7 @@ def from_notes(
 
         piano_roll_notes.append(note_data)
 
-    result: PianoRollData = {
+    result: dict = {
         "notes": piano_roll_notes,
         "tempo": tempo,
         "timeSignature": {"numerator": 4, "denominator": 4},
@@ -79,7 +83,7 @@ def from_midi_numbers(
     durations: Optional[List[float]] = None,
     start_times: Optional[List[float]] = None,
     tempo: int = 120,
-) -> PianoRollData:
+) -> PianoRollDataClass:
     """
     MIDI 노트 번호 리스트에서 피아노롤 생성
 
@@ -108,7 +112,7 @@ def from_frequencies(
     durations: Optional[List[float]] = None,
     start_times: Optional[List[float]] = None,
     tempo: int = 120,
-) -> PianoRollData:
+) -> PianoRollDataClass:
     """
     주파수(Hz) 리스트에서 피아노롤 생성
 
@@ -138,7 +142,7 @@ def from_tts_output(
     alignment: List[Tuple[str, float, float]],
     f0_data: Optional[List[float]] = None,
     tempo: int = 120,
-) -> Dict:
+) -> PianoRollDataClass:
     """
     TTS 모델의 정렬 결과를 피아노롤로 변환
 
@@ -198,10 +202,10 @@ def from_tts_output(
             f0_data, alignment[-1][2], tempo, pixels_per_beat
         )
 
-    return result
+    return clean_piano_roll_data(result)
 
 
-def from_midi_generation(generated_sequence: List[Dict], tempo: int = 120) -> Dict:
+def from_midi_generation(generated_sequence: List[Dict], tempo: int = 120) -> PianoRollDataClass:
     """
     MIDI 생성 모델 출력을 피아노롤로 변환
 
@@ -236,7 +240,7 @@ def from_midi_generation(generated_sequence: List[Dict], tempo: int = 120) -> Di
 
         notes.append(note)
 
-    return {
+    result = {
         "notes": notes,
         "tempo": tempo,
         "timeSignature": {"numerator": 4, "denominator": 4},
@@ -244,6 +248,8 @@ def from_midi_generation(generated_sequence: List[Dict], tempo: int = 120) -> Di
         "snapSetting": "1/4",
         "pixelsPerBeat": pixels_per_beat,
     }
+
+    return clean_piano_roll_data(result)
 
 
 def _create_f0_line_data(
@@ -391,7 +397,7 @@ def analyze_notes(piano_roll_data: Dict) -> Dict:
 
 def auto_analyze(
     model_output_data: Union[List, Dict], output_type: str = "auto"
-) -> Dict:
+) -> PianoRollDataClass:
     """
     모델 출력을 자동으로 분석해서 피아노롤 형식으로 변환
 

--- a/frontend/types/component.ts
+++ b/frontend/types/component.ts
@@ -1,4 +1,5 @@
 // Svelte component props types
+import type { PianoRollData, Note, LineLayerConfig, TimeSignature } from './piano_roll_data';
 
 export interface PianoRollProps {
   width?: number;
@@ -7,35 +8,16 @@ export interface PianoRollProps {
   timelineHeight?: number;
   elem_id?: string;
   audio_data?: string | null;
-  curve_data?: object | null;
+  curve_data?: Record<string, any> | null;
   segment_data?: Array<any> | null;
-  line_data?: object | null;
+  line_data?: Record<string, LineLayerConfig> | null;
   use_backend_audio?: boolean;
-  notes?: Array<{
-    id: string;
-    start: number;
-    duration: number;
-    startFlicks?: number;
-    durationFlicks?: number;
-    startSeconds?: number;
-    durationSeconds?: number;
-    endSeconds?: number;
-    startBeats?: number;
-    durationBeats?: number;
-    startTicks?: number;
-    durationTicks?: number;
-    startSample?: number;
-    durationSamples?: number;
-    pitch: number;
-    velocity: number;
-    lyric?: string;
-    phoneme?: string;
-  }>;
+  notes?: Note[];
 }
 
 export interface ToolbarProps {
   tempo?: number;
-  timeSignature?: { numerator: number; denominator: number };
+  timeSignature?: TimeSignature;
   editMode?: string;
   snapSetting?: string;
   isPlaying?: boolean;
@@ -50,15 +32,7 @@ export interface LayerControlPanelProps {
 export interface DebugComponentProps {
   currentFlicks?: number;
   tempo?: number;
-  notes?: Array<{
-    id: string;
-    start: number;
-    duration: number;
-    pitch: number;
-    velocity: number;
-    lyric?: string;
-    phoneme?: string;
-  }>;
+  notes?: Note[];
   isPlaying?: boolean;
   isRendering?: boolean;
 }

--- a/frontend/types/piano_roll_data.ts
+++ b/frontend/types/piano_roll_data.ts
@@ -1,0 +1,62 @@
+export interface TimeSignature {
+  numerator: number;
+  denominator: number;
+}
+
+export interface Note {
+  id: string;
+  start: number;
+  duration: number;
+  startFlicks?: number;
+  durationFlicks?: number;
+  startSeconds?: number;
+  durationSeconds?: number;
+  endSeconds?: number;
+  startBeats?: number;
+  durationBeats?: number;
+  startTicks?: number;
+  durationTicks?: number;
+  startSample?: number;
+  durationSamples?: number;
+  pitch: number;
+  velocity: number;
+  lyric?: string;
+  phoneme?: string;
+}
+
+export interface LineDataPoint {
+  x: number;
+  y: number;
+}
+
+export interface LineLayerConfig {
+  color: string;
+  lineWidth: number;
+  yMin: number;
+  yMax: number;
+  position?: string;
+  renderMode?: string;
+  visible?: boolean;
+  opacity?: number;
+  dataType?: string;
+  unit?: string;
+  originalRange?: Record<string, any>;
+  data: LineDataPoint[];
+}
+
+export interface PianoRollData {
+  notes: Note[];
+  tempo: number;
+  timeSignature: TimeSignature;
+  editMode: string;
+  snapSetting: string;
+  pixelsPerBeat?: number;
+  sampleRate?: number;
+  ppqn?: number;
+  audio_data?: string | null;
+  curve_data?: Record<string, any> | null;
+  segment_data?: Array<Record<string, any>> | null;
+  line_data?: Record<string, LineLayerConfig> | null;
+  use_backend_audio?: boolean;
+  waveform_data?: Array<Record<string, number>> | null;
+}


### PR DESCRIPTION
## Summary
- export new dataclasses from library entrypoint
- add TypeScript definitions for PianoRoll data structures
- refactor component prop types to use shared interfaces

## Testing
- `pre-commit run --files backend/gradio_pianoroll/__init__.py frontend/types/component.ts frontend/types/piano_roll_data.ts` *(fails: Could not find a version that satisfies the requirement types-pkg-resources)*

------
https://chatgpt.com/codex/tasks/task_e_68518cc6a3148328baef89eba2f2c195